### PR TITLE
OpenAPI generation via utoipa crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minicbor"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2896,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a17e5ac65b318f397182ae94e532da0ba56b88dd1200b774715d36c4943b1c3"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e763e24ba2bf0c72bc6be883f967f794a019fafd1b86ba1daff9c91a7edd30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756feca3afcbb1487a1d01f4ecd94cf8ec98ea074c55a69e7136d29fb6166029"
+dependencies = [
+ "sha2 0.9.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3257,15 @@ checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
 dependencies = [
  "digest 0.10.3",
  "keccak",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
+dependencies = [
+ "dirs-next",
 ]
 
 [[package]]
@@ -3804,6 +3858,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "utoipa"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bdc651bbdd526cc02a07dea1dfb49030a1757178c7552185baccd65ef6f741"
+dependencies = [
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36592981d9d4ff5900ec9a09634a9373231324f8a7ba918bb3351b4b2987e4e1"
+dependencies = [
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36d43e1e334e510a29ab84fc1d110780690495a4608faecedd3639e1cf7a2a9"
+dependencies = [
+ "actix-web",
+ "lazy_static",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,6 +3941,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+ "utoipa",
+ "utoipa-swagger-ui",
  "wiremock",
 ]
 

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -35,6 +35,9 @@ ethers-core = "0.13.0"
 primitive-types = "0.11"
 serde_with = "1.14"
 ethabi = "17.0.0"
+utoipa = { version = "1.1.0", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "1.1.0", features = ["actix-web"] }
+
 
 [dev-dependencies]
 const_format = "0.2"

--- a/verification/src/http_server/handlers/status.rs
+++ b/verification/src/http_server/handlers/status.rs
@@ -1,5 +1,12 @@
 use actix_web::{HttpResponse, Responder};
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    responses(
+        (status = 200, description = "Service is healthy"),
+    ),
+)]
 pub async fn status() -> impl Responder {
     HttpResponse::Ok().finish()
 }

--- a/verification/src/http_server/handlers/verification/mod.rs
+++ b/verification/src/http_server/handlers/verification/mod.rs
@@ -5,18 +5,19 @@ use std::{collections::BTreeMap, fmt::Display};
 
 use crate::{compiler::CompilerVersion, solidity::VerificationSuccess, DisplayBytes};
 use serde::{Deserialize, Serialize};
+use utoipa::Component;
 
 pub mod solidity;
 pub mod sourcify;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Component)]
 pub struct VerificationResponse {
     pub message: String,
     pub result: Option<VerificationResult>,
     pub status: VerificationStatus,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Component)]
 pub struct VerificationResult {
     pub file_name: String,
     pub contract_name: String,
@@ -68,7 +69,7 @@ impl From<(CompilerInput, CompilerVersion, VerificationSuccess)> for Verificatio
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Component)]
 pub enum VerificationStatus {
     #[serde(rename = "0")]
     Ok,

--- a/verification/src/http_server/handlers/verification/solidity/mod.rs
+++ b/verification/src/http_server/handlers/verification/solidity/mod.rs
@@ -1,5 +1,5 @@
 mod contract_verifier;
-mod types;
+pub(crate) mod types;
 
 pub mod multi_part;
 pub mod standard_json;

--- a/verification/src/http_server/handlers/verification/solidity/multi_part.rs
+++ b/verification/src/http_server/handlers/verification/solidity/multi_part.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 #[utoipa::path(
     post,
     path = "/api/v1/solidity/verify/multiple-files",
-    request_body = MultiPartFiles,
+    request_body(content = MultiPartFiles, content_type = "application/json", description = "Description for request body"),
     responses(
         (
             status = 200,
@@ -84,14 +84,6 @@ use std::str::FromStr;
                 }
             }),
         ),
-    ),
-    params(
-        ("multi_part_files" = MultiPartFiles, description = "Param 1 description", example = json!({
-            "files": {
-                "file1.sol": "...",
-                "file2.sol": "...",
-            },
-        })),
     ),
     tag = "solidity"
 )]

--- a/verification/src/http_server/handlers/verification/solidity/multi_part.rs
+++ b/verification/src/http_server/handlers/verification/solidity/multi_part.rs
@@ -14,6 +14,87 @@ use actix_web::{
 };
 use std::str::FromStr;
 
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/solidity/verify/multiple-files",
+    request_body = MultiPartFiles,
+    responses(
+        (
+            status = 200,
+            description = "Verification successful",
+            body = VerificationResponse,
+            example = json!({
+                "status": "success",
+                "result": {
+                    "contracts": {
+                        "contract1": {
+                            "abi": "...",
+                            "bytecode": "...",
+                            "compiler": "solc",
+                            "compiler_version": "0.5.0",
+                            "optimized": false,
+                            "source": "...",
+                            "source_map": "...",
+                            "source_map_url": "...",
+                            "source_url": "...",
+                            "version": "0.5.0",
+                        },
+                        "contract2": {
+                            "abi": "...",
+                            "bytecode": "...",
+                            "compiler": "solc",
+                            "compiler_version": "0.5.0",
+                            "optimized": false,
+                            "source": "...",
+                            "source_map": "...",
+                            "source_map_url": "...",
+                            "source_url": "...",
+                            "version": "0.5.0",
+                        },
+                    },
+                    "errors": [
+                        {
+                            "contract": "contract1",
+                            "error": "...",
+                            "file": "...",
+                            "line": 0,
+                            "location": "...",
+                            "severity": "error",
+                            "title": "...",
+                        },
+                        {
+                            "contract": "contract2",
+                            "error": "...",
+                            "file": "...",
+                            "line": 0,
+                            "location": "...",
+                            "severity": "error",
+                            "title": "...",
+                        },
+                    ],
+                    "metadata": {
+                        "compiler": "solc",
+                        "compiler_version": "0.5.0",
+                        "language": "Solidity",
+                        "language_version": "0.5.0",
+                        "optimized": false,
+                        "version": "0.5.0",
+                    },
+                }
+            }),
+        ),
+    ),
+    params(
+        ("multi_part_files" = MultiPartFiles, description = "Param 1 description", example = json!({
+            "files": {
+                "file1.sol": "...",
+                "file2.sol": "...",
+            },
+        })),
+    ),
+    tag = "solidity"
+)]
 pub async fn verify(
     compilers: web::Data<Compilers<CompilerFetcher>>,
     params: Json<VerificationRequest<MultiPartFiles>>,

--- a/verification/src/http_server/handlers/verification/solidity/types.rs
+++ b/verification/src/http_server/handlers/verification/solidity/types.rs
@@ -4,8 +4,9 @@ use ethers_solc::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
+use utoipa::Component;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Component)]
 pub struct VerificationRequest<T> {
     pub deployed_bytecode: String,
     pub creation_bytecode: String,
@@ -15,7 +16,7 @@ pub struct VerificationRequest<T> {
     pub content: T,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Component)]
 pub struct MultiPartFiles {
     sources: BTreeMap<PathBuf, String>,
     evm_version: String,

--- a/verification/src/http_server/routers/app.rs
+++ b/verification/src/http_server/routers/app.rs
@@ -1,6 +1,10 @@
 use super::{configure_router, Router, SolidityRouter, SourcifyRouter};
-use crate::{config::Config, http_server::handlers::status};
+use crate::{config::Config, http_server::handlers::{status}};
 use actix_web::web;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+use crate::http_server::handlers::verification::{solidity::{self, types::{MultiPartFiles}}};
+use crate::http_server::handlers::verification::{VerificationResponse, VerificationStatus, VerificationResult};
 
 pub struct AppRouter {
     solidity: Option<SolidityRouter>,
@@ -21,10 +25,28 @@ impl AppRouter {
     }
 }
 
+#[derive(OpenApi)]
+#[openapi(
+    handlers(
+        status::status,
+        solidity::multi_part::verify,
+    ),
+    components(
+        VerificationResponse,
+        MultiPartFiles,
+        VerificationResult,
+        VerificationStatus,
+    ),
+    tags(),
+    modifiers()
+)]
+pub struct ApiDoc;
+
 impl Router for AppRouter {
     fn register_routes(&self, service_config: &mut web::ServiceConfig) {
         service_config
             .route("/health", web::get().to(status::status))
+            .service(SwaggerUi::new("/docs/{_:.*}").url("/docs/schema.json", ApiDoc::openapi()))
             .service(
                 web::scope("/api/v1")
                     .service(web::scope("/solidity").configure(configure_router(&self.solidity)))

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -6,6 +6,7 @@ mod http_server;
 mod scheduler;
 mod solidity;
 mod types;
+mod openapi;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This PR represents `utoipa` crate in the series of experiments with OpenAPI generating crates (check #1).

Results could be seen through `cargo run` and accessing [localhost:8043/docs/](https://localhost:8043/docs/)